### PR TITLE
Fix freeze bug in FlashKeyValue.ino

### DIFF
--- a/examples/Creating a Flash-Optimised Key-Value Store/FlashKeyValue/FlashKeyValue.ino
+++ b/examples/Creating a Flash-Optimised Key-Value Store/FlashKeyValue/FlashKeyValue.ino
@@ -35,10 +35,14 @@ void setup()
 
     // Initialize the flash IAP block device and print the memory layout
     blockDevice.init();
-    Serial.println("FlashIAP block device size: " +  blockDevice.size());
-    Serial.println("FlashIAP block device read size: " + blockDevice.get_read_size());
-    Serial.println("FlashIAP block device program size: " + blockDevice.get_program_size());
-    Serial.println("FlashIAP block device erase size: " + blockDevice.get_erase_size());
+    Serial.print("FlashIAP block device size: ");
+    Serial.println(blockDevice.size());
+    Serial.print("FlashIAP block device read size: ");
+    Serial.println(blockDevice.get_read_size());
+    Serial.print("FlashIAP block device program size: ");
+    Serial.println(blockDevice.get_program_size());
+    Serial.print("FlashIAP block device erase size: ");
+    Serial.println(blockDevice.get_erase_size());
     // Deinitialize the device
     blockDevice.deinit();
 


### PR DESCRIPTION
The old version contained code like this: Serial.println("FlashIAP block device size: " +  blockDevice.size());

This adds a large number (the block device size) to the address of the string literal before the + sign. It becomes an illegal address, which triggers a BusFault exception, and the sketch freezes after printing "FlashIAPBlockDevice + TDBStore Test."