### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -46,14 +46,17 @@ jobs:
               - examples/Portenta H7 as a WiFi Access Point/SimpleWebServer
               - examples/Setting Up Portenta H7 For Arduino/Blink
               - examples/Vision Shield to SD Card bmp/visionShieldBitmap
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7
 
           - fqbn: arduino:mbed_portenta:envie_m7:target_core=cm4
             sketch-paths: |
               - examples/Dual Core Processing/BlinkGreenLed_M4
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7-target_core-cm4
 
           - fqbn: arduino:mbed_edge:edge_control
             sketch-paths: |
               - examples/Edge Control Getting Started
+            artifact-name-suffix: arduino-mbed_edge-edge_control
 
     steps:
       - name: Checkout
@@ -86,5 +89,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .